### PR TITLE
Bump plugin version after added research commands

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "taches-cc-resources",
   "description": "Curated Claude Code skills and commands for prompt engineering, MCP servers, subagents, hooks, and productivity workflows",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Lex Christopherson",
     "email": "lex@glittercowboy.com"


### PR DESCRIPTION
As title says. After adding research commands the plugin version hasn't been bumped which makes update commands unavailable by marketplace.