### PR TITLE
fix: quote argument-hint in heal-skill to prevent YAML parsing error

### DIFF
--- a/commands/heal-skill.md
+++ b/commands/heal-skill.md
@@ -1,6 +1,6 @@
 ---
 description: Heal skill documentation by applying corrections discovered during execution with approval workflow
-argument-hint: [optional: specific issue to fix]
+argument-hint: "[optional: specific issue to fix]"
 allowed-tools: [Read, Edit, Bash(ls:*), Bash(git:*)]
 ---
 


### PR DESCRIPTION
## TL;DR

I created this pull request because I wanted to use this plugin in purely a project scope. In that scenario, `/heal-skill` completely crashes the Claude Code session with a crazy Node error. This one line seems to fix the issue.

## Summary

- Quotes the `argument-hint` value in `commands/heal-skill.md` to prevent YAML from parsing `[optional: specific issue to fix]` as a flow sequence containing a mapping object (`{optional: "..."}`) instead of a plain string
- This caused React error #31 ("Objects are not valid as a React child") when Claude Code tried to render the parsed object in the UI
- The bug only manifested when the command was loaded locally (project-level), not when installed globally via plugin

## Test plan

- [x] Run `/heal-skill` locally within the repo and verify no React error #31
- [x] Confirm the argument hint displays correctly in the Claude Code UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)